### PR TITLE
Laravel default cache driver

### DIFF
--- a/src/Drivers/LaravelCacheDriver.php
+++ b/src/Drivers/LaravelCacheDriver.php
@@ -2,6 +2,7 @@
 
 namespace Sammyjo20\SaloonCachePlugin\Drivers;
 
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Contracts\Cache\Repository;
 use Sammyjo20\SaloonCachePlugin\Data\CachedResponse;
 use Sammyjo20\SaloonCachePlugin\Interfaces\DriverInterface;
@@ -12,9 +13,9 @@ class LaravelCacheDriver implements DriverInterface
      * @param Repository $store
      */
     public function __construct(
-        protected Repository $store,
+        protected ?Repository $store = null,
     ) {
-        //
+        $this->store = $this->store ?: Cache::store();
     }
 
     /**

--- a/tests/Feature/Laravel/LaravelDefaultCacheDriverTest.php
+++ b/tests/Feature/Laravel/LaravelDefaultCacheDriverTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Support\Facades\Cache;
+use Sammyjo20\Saloon\Http\MockResponse;
+use Sammyjo20\Saloon\Clients\MockClient;
+use Sammyjo20\SaloonCachePlugin\Tests\Fixtures\Requests\LaravelCachedUserRequest;
+use Sammyjo20\SaloonCachePlugin\Tests\Fixtures\Requests\LaravelDefaultCachedUserRequest;
+
+beforeEach(function () {
+    Cache::store('file')->clear();
+});
+
+it('will return a cached response', function () {
+    $mockClient = new MockClient([
+        MockResponse::make(['name' => 'Sam']),
+        MockResponse::make(['name' => 'Gareth']),
+    ]);
+
+    $requestA = new LaravelDefaultCachedUserRequest();
+    $responseA = $requestA->send($mockClient);
+
+    expect($responseA->isCached())->toBeFalse();
+    expect($responseA->json())->toEqual(['name' => 'Sam']);
+
+    $requestB = new LaravelDefaultCachedUserRequest();
+    $responseB = $requestB->send($mockClient);
+
+    expect($responseB->isCached())->toBeTrue();
+    expect($responseB->header('X-Saloon-Cache'))->toEqual('Cached');
+    expect($responseB->json())->toEqual(['name' => 'Sam']);
+});

--- a/tests/Fixtures/Requests/LaravelDefaultCachedUserRequest.php
+++ b/tests/Fixtures/Requests/LaravelDefaultCachedUserRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Sammyjo20\SaloonCachePlugin\Tests\Fixtures\Requests;
+
+use Illuminate\Support\Facades\Cache;
+use Sammyjo20\Saloon\Constants\Saloon;
+use Sammyjo20\Saloon\Http\SaloonRequest;
+use Sammyjo20\SaloonCachePlugin\Drivers\LaravelCacheDriver;
+use Sammyjo20\SaloonCachePlugin\Interfaces\DriverInterface;
+use Sammyjo20\SaloonCachePlugin\Traits\AlwaysCacheResponses;
+use Sammyjo20\SaloonCachePlugin\Tests\Fixtures\Connectors\TestConnector;
+
+class LaravelDefaultCachedUserRequest extends SaloonRequest
+{
+    use AlwaysCacheResponses;
+
+    protected ?string $connector = TestConnector::class;
+
+    protected ?string $method = Saloon::GET;
+
+    public function defineEndpoint(): string
+    {
+        return '/user';
+    }
+
+    public function cacheDriver(): DriverInterface
+    {
+        return new LaravelCacheDriver();
+    }
+
+    public function cacheTTLInSeconds(): int
+    {
+        return 60;
+    }
+}


### PR DESCRIPTION
Ability to use Laravel default cache driver 

```php
    public function cacheDriver(): DriverInterface
    {
        return new LaravelCacheDriver();
    }
```